### PR TITLE
Fix osx/linux path problem with props file

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -111,11 +111,13 @@ Push-Location $libgit2Directory
     </ItemGroup>
     <ItemGroup Condition=" '`$(OS)' == 'Unix' And Exists('/Library/Frameworks') ">
         <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib">
+            <Link>lib$binaryFilename.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
         <ItemGroup Condition=" '`$(OS)' == 'Unix' And !Exists('/Library/Frameworks') ">
         <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\lib$binaryFilename.so">
+            <Link>lib$binaryFilename.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -23,11 +23,13 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(OS)' == 'Unix' And Exists('/Library/Frameworks') ">
         <None Include="$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-a56db99.dylib">
+            <Link>libgit2-a56db99.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
         <ItemGroup Condition=" '$(OS)' == 'Unix' And !Exists('/Library/Frameworks') ">
         <None Include="$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\libgit2-a56db99.so">
+            <Link>libgit2-a56db99.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>


### PR DESCRIPTION
This change ensures that the osx and linux native binaries get copied to the correct location during build, regardless of project/solution structure.

This fixes #10.