### PR TITLE
Add exists checks to props file

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -92,27 +92,27 @@ Push-Location $libgit2Directory
         <EmbeddedResource Include="`$(MSBuildThisFileDirectory)\..\libgit2\libgit2_hash.txt" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.dll">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.dll">
             <Link>NativeBinaries\amd64\$binaryFilename.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.pdb">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\$binaryFilename.pdb">
             <Link>NativeBinaries\amd64\$binaryFilename.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.dll">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.dll">
             <Link>NativeBinaries\x86\$binaryFilename.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.pdb">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\$binaryFilename.pdb">
             <Link>NativeBinaries\x86\$binaryFilename.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib">
             <Link>NativeBinaries\osx\lib$binaryFilename.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="`$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\lib$binaryFilename.so">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\lib$binaryFilename.so">
             <Link>NativeBinaries\linux\amd64\lib$binaryFilename.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -4,27 +4,27 @@
         <EmbeddedResource Include="$(MSBuildThisFileDirectory)\..\libgit2\libgit2_hash.txt" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.dll')" Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.dll">
             <Link>NativeBinaries\amd64\git2-a56db99.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.pdb')" Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\amd64\git2-a56db99.pdb">
             <Link>NativeBinaries\amd64\git2-a56db99.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.dll')" Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.dll">
             <Link>NativeBinaries\x86\git2-a56db99.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.pdb')" Include="$(MSBuildThisFileDirectory)\..\libgit2\windows\x86\git2-a56db99.pdb">
             <Link>NativeBinaries\x86\git2-a56db99.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-a56db99.dylib">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-a56db99.dylib')" Include="$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-a56db99.dylib">
             <Link>NativeBinaries\osx\libgit2-a56db99.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\libgit2-a56db99.so">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\libgit2-a56db99.so')" Include="$(MSBuildThisFileDirectory)\..\libgit2\linux\amd64\libgit2-a56db99.so">
             <Link>NativeBinaries\linux\amd64\libgit2-a56db99.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
The native binary files will be copied if only they actually exist, preventing a build error if they are missing.

I didn't see a reson to add the check to the files that are included in the repo, so it's just for the build outputs.