### PR TITLE
Disable PackageAnalysis mode while packing

### DIFF
--- a/download.build.artifacts.and.package.ps1
+++ b/download.build.artifacts.and.package.ps1
@@ -112,11 +112,8 @@ $osxBins = Get-ChildItem -Path $path -Filter "binaries-osx-*.zip"
 Write-Host -ForegroundColor "Yellow" "Extracting build artifacts"
 Add-Type -assembly "System.Io.Compression.Filesystem"
 [Io.Compression.ZipFile]::ExtractToDirectory("$($package.FullName)", "$($package.FullName).ext")
-Remove-Item "$($package.FullName)"
 [Io.Compression.ZipFile]::ExtractToDirectory("$($linuxBins.FullName)", "$($linuxBins.FullName).ext")
-Remove-Item "$($linuxBins.FullName)"
 [Io.Compression.ZipFile]::ExtractToDirectory("$($osxBins.FullName)", "$($osxBins.FullName).ext")
-Remove-Item "$($osxBins.FullName)"
 
 Write-Host -ForegroundColor "Yellow" "Including non Windows build artifacts"
 Move-Item "$($linuxBins.FullName).ext\libgit2\linux\amd64\*.so" "$($package.FullName).ext\libgit2\linux\amd64"
@@ -130,7 +127,13 @@ Remove-Item -Path ".\_rels\" -Recurse
 Remove-Item -Path ".\package\" -Recurse
 Remove-Item -Path '.\`[Content_Types`].xml'
 & "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path" -NoPackageAnalysis -Verbosity "detailed"
-Pop-Location
-Remove-Item "$path\*.ext" -Recurse
 
-explorer "$path"
+$newPackage = Get-ChildItem -Path $path -Filter "*.nupkg"
+Pop-Location
+
+Write-Host -ForegroundColor "Yellow" "Copying package `"$($newPackage.Name)`" to `"$root`""
+
+Move-Item -Path "$($newPackage.FullName)" -Destination "$root\$($newPackage.Name)"
+
+Write-Host -ForegroundColor "Yellow" "Removing temporary folder"
+Remove-Item "$path" -Recurse

--- a/download.build.artifacts.and.package.ps1
+++ b/download.build.artifacts.and.package.ps1
@@ -124,15 +124,9 @@ Remove-Item "$($package.FullName).ext\libgit2\linux\amd64\addbinaries.here"
 Move-Item "$($osxBins.FullName).ext\libgit2\osx\*.dylib" "$($package.FullName).ext\libgit2\osx"
 Remove-Item "$($package.FullName).ext\libgit2\osx\addbinaries.here"
 
-Write-Host -ForegroundColor "Yellow" "Listing binaries to be packaged"
-Foreach ($item in (Get-ChildItem "$path" -Filter "*git2-*.*" -Recurse))
-{
-  Write-Host -ForegroundColor "White" "-> $($item.FullName)"
-}
-
 Write-Host -ForegroundColor "Yellow" "Building final NuGet package"
 Push-location "$($package.FullName).ext"
-& "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path" -NoPackageAnalysis
+& "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path" -NoPackageAnalysis -Verbosity "detailed"
 Pop-Location
 Remove-Item "$path\*.ext" -Recurse
 

--- a/download.build.artifacts.and.package.ps1
+++ b/download.build.artifacts.and.package.ps1
@@ -132,7 +132,7 @@ Foreach ($item in (Get-ChildItem "$path" -Filter "*git2-*.*" -Recurse))
 
 Write-Host -ForegroundColor "Yellow" "Building final NuGet package"
 Push-location "$($package.FullName).ext"
-& "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path"
+& "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path" -NoPackageAnalysis
 Pop-Location
 Remove-Item "$path\*.ext" -Recurse
 

--- a/download.build.artifacts.and.package.ps1
+++ b/download.build.artifacts.and.package.ps1
@@ -126,6 +126,9 @@ Remove-Item "$($package.FullName).ext\libgit2\osx\addbinaries.here"
 
 Write-Host -ForegroundColor "Yellow" "Building final NuGet package"
 Push-location "$($package.FullName).ext"
+Remove-Item -Path ".\_rels\" -Recurse
+Remove-Item -Path ".\package\" -Recurse
+Remove-Item -Path '.\`[Content_Types`].xml'
 & "$root/Nuget.exe" pack "LibGit2Sharp.NativeBinaries.nuspec" -OutputDirectory "$path" -NoPackageAnalysis -Verbosity "detailed"
 Pop-Location
 Remove-Item "$path\*.ext" -Recurse


### PR DESCRIPTION
Included changes trigger the following output

```
PS F:\libgit2sharp.nativebinaries> .\download.build.artifacts.and.package.ps1
Creating temporary folder at "C:\Users\ntk\AppData\Local\Temp\uwdquwfw.pdf"
Retrieving LibGit2Sharp.NativeBinaries latest CI statuses of "master"
-> Get https://api.github.com/repos/libgit2/libgit2sharp.nativebinaries/commits/master/statuses
Retrieving AppVeyor build "1.0.106"
-> Get https://ci.appveyor.com/api/projects/libgit2/libgit2sharp-nativebinaries/build/1.0.106
Retrieving AppVeyor job "477c461168fy0o28" artifacts
-> Get https://ci.appveyor.com/api/buildjobs/477c461168fy0o28/artifacts
Downloading "LibGit2Sharp.NativeBinaries.1.0.106.nupkg"
-> Get https://ci.appveyor.com/api/buildjobs/477c461168fy0o28/artifacts/LibGit2Sharp.NativeBinaries.1.0.106.nupkg
Retrieving Travis build "87090683"
-> Get https://api.travis-ci.org/builds/87090683
Downloading "binaries-linux-91.zip"
-> Get https://dl.bintray.com/libgit2/compiled-binaries/binaries-linux-91.zip
Downloading "binaries-osx-91.zip"
-> Get https://dl.bintray.com/libgit2/compiled-binaries/binaries-osx-91.zip
Build artifacts have been downloaded at "C:\Users\ntk\AppData\Local\Temp\uwdquwfw.pdf"
Extracting build artifacts
Including non Windows build artifacts
Building final NuGet package
Attempting to build package from 'LibGit2Sharp.NativeBinaries.nuspec'.

Id: LibGit2Sharp.NativeBinaries
Version: 1.0.106
Authors: LibGit2Sharp contributors
Description: Native binaries for LibGit2Sharp
License Url: https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING
Project Url: https://github.com/libgit2/libgit2sharp.nativebinaries
Dependencies: None

Added file '[Content_Types].xml'.
Added file 'build\LibGit2Sharp.NativeBinaries.props'.
Added file 'libgit2\libgit2.license.txt'.
Added file 'libgit2\libgit2_filename.txt'.
Added file 'libgit2\libgit2_hash.txt'.
Added file 'libgit2\LibGit2Sharp.dll.config'.
Added file 'libgit2\linux\amd64\libgit2-821131f.so'.
Added file 'libgit2\osx\libgit2-821131f.dylib'.
Added file 'libgit2\windows\amd64\git2-821131f.dll'.
Added file 'libgit2\windows\amd64\git2-821131f.pdb'.
Added file 'libgit2\windows\x86\git2-821131f.dll'.
Added file 'libgit2\windows\x86\git2-821131f.pdb'.

Successfully created package 'C:\Users\ntk\AppData\Local\Temp\uwdquwfw.pdf\LibGit2Sharp.NativeBinaries.1.0.106.nupkg'.
```