### PR TITLE
Support package.json magic

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -99,27 +99,27 @@ Push-Location $libgit2Directory
         <EmbeddedResource Include="`$(MSBuildThisFileDirectory)\..\libgit2\libgit2_filename.txt" />
     </ItemGroup>
     <ItemGroup>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\$binaryFilename.dll">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\$binaryFilename.dll">
             <Link>lib\win32\x64\$binaryFilename.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\$binaryFilename.pdb">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\$binaryFilename.pdb">
             <Link>lib\win32\x64\$binaryFilename.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\$binaryFilename.dll">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\$binaryFilename.dll">
             <Link>lib\win32\x86\$binaryFilename.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\$binaryFilename.pdb">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\$binaryFilename.pdb">
             <Link>lib\win32\x86\$binaryFilename.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\osx\lib$binaryFilename.dylib">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\osx\native\lib$binaryFilename.dylib')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\osx\native\lib$binaryFilename.dylib">
             <Link>lib\osx\lib$binaryFilename.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\libgit2\linux\x86_64\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\libgit2\linux\x86_64\lib$binaryFilename.so">
+        <None Condition="Exists('`$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\lib$binaryFilename.so">
             <Link>lib\linux\x86_64\lib$binaryFilename.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/build.libgit2.ps1
+++ b/build.libgit2.ps1
@@ -20,8 +20,8 @@ Set-StrictMode -Version Latest
 
 $projectDirectory = Split-Path $MyInvocation.MyCommand.Path
 $libgit2Directory = Join-Path $projectDirectory "libgit2"
-$x86Directory = Join-Path $projectDirectory "nuget.package\libgit2\win32\x86"
-$x64Directory = Join-Path $projectDirectory "nuget.package\libgit2\win32\x64"
+$x86Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x86\native"
+$x64Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x64\native"
 $hashFile = Join-Path $projectDirectory "nuget.package\libgit2\libgit2_hash.txt"
 $sha = Get-Content $hashFile 
 

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -27,8 +27,12 @@ PACKAGEPATH="nuget.package/libgit2"
 LIBEXT="so"
 
 if [ $OS == "Linux" ]; then
+	if [ "$ARCH" == "x86_64" ]; then
+		ARCH="x64"
+	fi
+
 	OSPATH="/linux"
-	ARCHPATH="/${ARCH}"
+	ARCHPATH="-$ARCH"
 elif [ $OS == "Darwin" ]; then
 	OSPATH="/osx"
 	LIBEXT="dylib"
@@ -37,8 +41,8 @@ else
 fi
 
 rm -rf $PACKAGEPATH$OSPATH
-mkdir -p $PACKAGEPATH$OSPATH$ARCHPATH
+mkdir -p $PACKAGEPATH$OSPATH$ARCHPATH/native
 
-cp libgit2/build/libgit2-$SHORTSHA.$LIBEXT $PACKAGEPATH$OSPATH$ARCHPATH
+cp libgit2/build/libgit2-$SHORTSHA.$LIBEXT $PACKAGEPATH$OSPATH$ARCHPATH/native
 
 exit $?

--- a/buildpackage.ps1
+++ b/buildpackage.ps1
@@ -9,10 +9,10 @@ $versionSuffix = ""
 if ($pre.IsPresent) { $versionSuffix = "-pre$BuildDate" }
 
 $projectDirectory = Split-Path $MyInvocation.MyCommand.Path
-$x86Directory = Join-Path $projectDirectory "nuget.package\libgit2\win32\x86"
-$x64Directory = Join-Path $projectDirectory "nuget.package\libgit2\win32\x64"
-$osxDirectory = Join-Path $projectDirectory "nuget.package\libgit2\osx"
-$linuxDirectory = Join-Path $projectDirectory "nuget.package\libgit2\linux\x86_64"
+$x86Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x86\native"
+$x64Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x64\native"
+$osxDirectory = Join-Path $projectDirectory "nuget.package\runtimes\osx\native"
+$linuxDirectory = Join-Path $projectDirectory "nuget.package\runtimes\linux-x64\native"
 
 if ( -Not (Test-Path $x86Directory\*.dll) )
 {

--- a/download.build.artifacts.and.package.ps1
+++ b/download.build.artifacts.and.package.ps1
@@ -116,10 +116,10 @@ Add-Type -assembly "System.Io.Compression.Filesystem"
 [Io.Compression.ZipFile]::ExtractToDirectory("$($osxBins.FullName)", "$($osxBins.FullName).ext")
 
 Write-Host -ForegroundColor "Yellow" "Including non Windows build artifacts"
-Move-Item "$($linuxBins.FullName).ext\libgit2\linux\x86_64\*.so" "$($package.FullName).ext\libgit2\linux\x86_64"
-Remove-Item "$($package.FullName).ext\libgit2\linux\x86_64\addbinaries.here"
-Move-Item "$($osxBins.FullName).ext\libgit2\osx\*.dylib" "$($package.FullName).ext\libgit2\osx"
-Remove-Item "$($package.FullName).ext\libgit2\osx\addbinaries.here"
+Move-Item "$($linuxBins.FullName).ext\runtimes\linux-x64\*.so" "$($package.FullName).ext\runtimes\linux-x64"
+Remove-Item "$($package.FullName).ext\runtimes\linux-x64\addbinaries.here"
+Move-Item "$($osxBins.FullName).ext\runtimes\osx\*.dylib" "$($package.FullName).ext\runtimes\osx"
+Remove-Item "$($package.FullName).ext\runtimes\osx\addbinaries.here"
 
 Write-Host -ForegroundColor "Yellow" "Building final NuGet package"
 Push-location "$($package.FullName).ext"

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -5,27 +5,27 @@
         <EmbeddedResource Include="$(MSBuildThisFileDirectory)\..\libgit2\libgit2_filename.txt" />
     </ItemGroup>
     <ItemGroup>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\git2-381caf5.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.dll">
             <Link>lib\win32\x64\git2-381caf5.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\libgit2\win32\x64\git2-381caf5.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.pdb">
             <Link>lib\win32\x64\git2-381caf5.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\git2-381caf5.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.dll">
             <Link>lib\win32\x86\git2-381caf5.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\libgit2\win32\x86\git2-381caf5.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.pdb">
             <Link>lib\win32\x86\git2-381caf5.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-381caf5.dylib')" Include="$(MSBuildThisFileDirectory)\..\libgit2\osx\libgit2-381caf5.dylib">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\osx\libgit2-381caf5.dylib')" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx\libgit2-381caf5.dylib">
             <Link>lib\osx\libgit2-381caf5.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\libgit2\linux\x86_64\libgit2-381caf5.so')" Include="$(MSBuildThisFileDirectory)\..\libgit2\linux\x86_64\libgit2-381caf5.so">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\libgit2-381caf5.so')" Include="$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\libgit2-381caf5.so">
             <Link>lib\linux\x86_64\libgit2-381caf5.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -5,27 +5,27 @@
         <EmbeddedResource Include="$(MSBuildThisFileDirectory)\..\libgit2\libgit2_filename.txt" />
     </ItemGroup>
     <ItemGroup>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\git2-381caf5.dll">
             <Link>lib\win32\x64\git2-381caf5.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\git2-381caf5.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\git2-381caf5.pdb">
             <Link>lib\win32\x64\git2-381caf5.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.dll">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\git2-381caf5.dll')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\git2-381caf5.dll">
             <Link>lib\win32\x86\git2-381caf5.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\git2-381caf5.pdb">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\git2-381caf5.pdb')" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\git2-381caf5.pdb">
             <Link>lib\win32\x86\git2-381caf5.pdb</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\osx\libgit2-381caf5.dylib')" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx\libgit2-381caf5.dylib">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\osx\native\libgit2-381caf5.dylib')" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx\native\libgit2-381caf5.dylib">
             <Link>lib\osx\libgit2-381caf5.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\libgit2-381caf5.so')" Include="$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\libgit2-381caf5.so">
+        <None Condition="Exists('$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\libgit2-381caf5.so')" Include="$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\libgit2-381caf5.so">
             <Link>lib\linux\x86_64\libgit2-381caf5.so</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/uploadbinaries.sh
+++ b/uploadbinaries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $TRAVIS_SECURE_ENV_VARS == "true" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then
+if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then
 
 pushd nuget.package
 


### PR DESCRIPTION
Apparently .NET Core type builds will:

a) eschew msbuild magic, and
b) place native binaries according to some directory hierarchy conventions.

Fixes #39 