### PR TITLE
Add more distros built via docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ before_install:
 
 install: true
 
-script:
-  - if [[ $RID == "osx" ]] || [[ $RID == "linux-x64" ]]; then ./build.libgit2.sh ; fi
-  - if [[ $RID != "osx" ]] && [[ $RID != "linux-x64" ]]; then ./dockerbuild.sh   ; fi
+script: if [[ $RID == "osx" ]]; then ./build.libgit2.sh ; else ./dockerbuild.sh ; fi
 
 after_success: ./uploadbinaries.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
       dist: trusty
       sudo: required
       env: RID=debian.9-x64
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: RID=alpine-x64
     - os: osx
       env: RID=osx
 

--- a/Dockerfile.alpine-x64
+++ b/Dockerfile.alpine-x64
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+WORKDIR /nativebinaries
+COPY . /nativebinaries/
+
+RUN apk add --no-cache bash build-base cmake curl-dev openssl-dev
+
+CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.linux-x64
+++ b/Dockerfile.linux-x64
@@ -1,0 +1,7 @@
+FROM ubuntu:14.04
+WORKDIR /nativebinaries
+COPY . /nativebinaries/
+
+RUN apt update && apt -y install cmake libcurl4-openssl-dev libssl-dev pkg-config
+
+CMD ["/bin/bash", "-c", "./build.libgit2.sh"]


### PR DESCRIPTION
This moves the Ubuntu build into docker and adds support for Alpine Linux, which was added as a supported distro for .NET Core 2.1.

