### PR TITLE
Remove curl from Dockerfiles

### DIFF
--- a/Dockerfile.alpine-x64
+++ b/Dockerfile.alpine-x64
@@ -2,6 +2,6 @@ FROM alpine:3.7
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apk add --no-cache bash build-base cmake curl-dev openssl-dev
+RUN apk add --no-cache bash build-base cmake openssl-dev
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.debian.9-x64
+++ b/Dockerfile.debian.9-x64
@@ -2,6 +2,6 @@ FROM debian:9
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake gcc libcurl4-openssl-dev libssl-dev pkg-config zlib1g-dev
+RUN apt update && apt -y install cmake gcc libssl-dev pkg-config zlib1g-dev
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.fedora-x64
+++ b/Dockerfile.fedora-x64
@@ -2,6 +2,6 @@ FROM fedora:26
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN yum -y install cmake gcc libcurl-devel make openssl-devel
+RUN yum -y install cmake gcc make openssl-devel
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.linux-x64
+++ b/Dockerfile.linux-x64
@@ -2,6 +2,6 @@ FROM ubuntu:14.04
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake libcurl4-openssl-dev libssl-dev pkg-config
+RUN apt update && apt -y install cmake libssl-dev pkg-config
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.rhel-x64
+++ b/Dockerfile.rhel-x64
@@ -2,6 +2,6 @@ FROM centos:6
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN yum -y install cmake gcc libcurl-devel make openssl-devel
+RUN yum -y install cmake gcc make openssl-devel
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.ubuntu.18.04-x64
+++ b/Dockerfile.ubuntu.18.04-x64
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake libcurl4-openssl-dev libssl-dev pkg-config zlib1g-dev
+RUN apt update && apt -y install cmake libssl-dev pkg-config zlib1g-dev
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]


### PR DESCRIPTION
Follow-up to #82, this removes the now unneeded curl dependencies from the Dockerfiles.