### PR TITLE
Use bundled zlib

### DIFF
--- a/Dockerfile.debian.9-x64
+++ b/Dockerfile.debian.9-x64
@@ -2,6 +2,6 @@ FROM debian:9
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake gcc libssl-dev pkg-config zlib1g-dev
+RUN apt update && apt -y install cmake gcc libssl-dev pkg-config
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.ubuntu.18.04-x64
+++ b/Dockerfile.ubuntu.18.04-x64
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake libssl-dev pkg-config zlib1g-dev
+RUN apt update && apt -y install cmake libssl-dev pkg-config
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -15,6 +15,7 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release \
       -DENABLE_TRACE=ON \
       -DLIBGIT2_FILENAME=git2-$SHORTSHA \
       -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" \
+      -DUSE_BUNDLED_ZLIB=ON \
       ..
 cmake --build .
 


### PR DESCRIPTION
@ethomson Any reason not to go ahead and do this now?

That way the only remaining native dependency is OpenSSL.