### PR TITLE
Add support for alpine 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       dist: trusty
       sudo: required
       env: RID=alpine-x64
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: RID=alpine.3.9-x64
     - os: osx
       env: RID=osx
 

--- a/Dockerfile.alpine.3.9-x64
+++ b/Dockerfile.alpine.3.9-x64
@@ -1,0 +1,7 @@
+FROM alpine:3.9
+WORKDIR /nativebinaries
+COPY . /nativebinaries/
+
+RUN apk add --no-cache bash build-base cmake openssl-dev
+
+CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -156,6 +156,10 @@ Push-Location $libgit2Directory
       <TargetPath>lib\alpine-x64\lib$binaryFilename.so</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
+    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\lib$binaryFilename.so">
+      <TargetPath>lib\alpine.3.9-x64\lib$binaryFilename.so</TargetPath>
+      CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
     <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
       <TargetPath>LibGit2Sharp.dll.config</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>

--- a/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
@@ -49,6 +49,10 @@
     <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so">
       <TargetPath>lib\alpine-x64\libgit2-572e4d8.so</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\libgit2-572e4d8.so">
+      <TargetPath>lib\alpine.3.9-x64\libgit2-572e4d8.so</TargetPath>
+      CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
     <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
       <TargetPath>LibGit2Sharp.dll.config</TargetPath>

--- a/nuget.package/libgit2/LibGit2Sharp.dll.config
+++ b/nuget.package/libgit2/LibGit2Sharp.dll.config
@@ -1,4 +1,4 @@
-﻿<configuration>
+<configuration>
     <dllmap os="linux" cpu="x86-64" wordsize="64" dll="git2-572e4d8" target="lib/linux-x64/libgit2-572e4d8.so" />
     <dllmap os="osx" cpu="x86,x86-64" dll="git2-572e4d8" target="lib/osx/libgit2-572e4d8.dylib" />
 </configuration>


### PR DESCRIPTION
We need a separate binary for Alpine 3.9 because it ships with OpenSSL 1.1.

:cry: