### PR TITLE
Improve props files

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -93,7 +93,6 @@ Push-Location $libgit2Directory
     $buildProperties = @"
 <Project>
   <PropertyGroup>
-    <MSBuildAllProjects>`$(MSBuildAllProjects);`$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>`$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>$sha</libgit2_hash>
     <libgit2_filename>$binaryFilename</libgit2_filename>
@@ -106,64 +105,15 @@ Push-Location $libgit2Directory
     $net46BuildProperties = @"
 <Project>
   <PropertyGroup>
-    <MSBuildAllProjects>`$(MSBuildAllProjects);`$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>`$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>$sha</libgit2_hash>
     <libgit2_filename>$binaryFilename</libgit2_filename>
   </PropertyGroup>
   <ItemGroup>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\$binaryFilename.dll">
-      <TargetPath>lib\win32\x64\$binaryFilename.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\$binaryFilename.pdb">
-      <TargetPath>lib\win32\x64\$binaryFilename.pdb</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\$binaryFilename.dll')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\$binaryFilename.dll">
-      <TargetPath>lib\win32\x86\$binaryFilename.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\$binaryFilename.pdb')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\$binaryFilename.pdb">
-      <TargetPath>lib\win32\x86\$binaryFilename.pdb</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\lib$binaryFilename.dylib')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\lib$binaryFilename.dylib">
-      <TargetPath>lib\osx\lib$binaryFilename.dylib</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\linux-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\ubuntu.18.04-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\rhel-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\fedora-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\debian.9-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\alpine-x64\lib$binaryFilename.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\lib$binaryFilename.so')" Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\lib$binaryFilename.so">
-      <TargetPath>lib\alpine.3.9-x64\lib$binaryFilename.so</TargetPath>
-      CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
-      <TargetPath>LibGit2Sharp.dll.config</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*" TargetPath="lib\win32\x86\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*" TargetPath="lib\win32\x64\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\**\*`" Exclude="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*" TargetPath="lib\%(RecursiveDir)..\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config" TargetPath="LibGit2Sharp.dll.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>
 "@

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>
     <libgit2_filename>git2-572e4d8</libgit2_filename>

--- a/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
@@ -1,62 +1,13 @@
 <Project>
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>
     <libgit2_filename>git2-572e4d8</libgit2_filename>
   </PropertyGroup>
   <ItemGroup>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.dll">
-      <TargetPath>lib\win32\x64\git2-572e4d8.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.pdb')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.pdb">
-      <TargetPath>lib\win32\x64\git2-572e4d8.pdb</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.dll">
-      <TargetPath>lib\win32\x86\git2-572e4d8.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.pdb')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.pdb">
-      <TargetPath>lib\win32\x86\git2-572e4d8.pdb</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\libgit2-572e4d8.dylib')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\libgit2-572e4d8.dylib">
-      <TargetPath>lib\osx\libgit2-572e4d8.dylib</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\linux-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\ubuntu.18.04-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\rhel-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\fedora-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\debian.9-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\alpine-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\alpine.3.9-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\alpine.3.9-x64\libgit2-572e4d8.so</TargetPath>
-      CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
-      <TargetPath>LibGit2Sharp.dll.config</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*" TargetPath="lib\win32\x86\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*" TargetPath="lib\win32\x64\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*" Exclude="$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*" TargetPath="lib\%(RecursiveDir)..\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config" TargetPath="LibGit2Sharp.dll.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/nuget.package/buildMultiTargeting/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/buildMultiTargeting/LibGit2Sharp.NativeBinaries.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\LibGit2Sharp.NativeBinaries.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\build\LibGit2Sharp.NativeBinaries.props" />
 </Project>

--- a/nuget.package/buildMultiTargeting/net46/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/buildMultiTargeting/net46/LibGit2Sharp.NativeBinaries.props
@@ -1,3 +1,0 @@
-<Project>
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\net46\LibGit2Sharp.NativeBinaries.props" />
-</Project>

--- a/nuget.package/buildMultiTargeting/net46/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/buildMultiTargeting/net46/LibGit2Sharp.NativeBinaries.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\..\build\net46\LibGit2Sharp.NativeBinaries.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\net46\LibGit2Sharp.NativeBinaries.props" />
 </Project>


### PR DESCRIPTION
This simplifies the props files that handles copying the binaries to the lib folder for .NET Framework and mono projects by using wildcards to find all of the binaries in the package.

No more needing to update the powershell script whenever a new binary is added, leading to errors like #94.

This also cleans up a few other miscellaneous things:

- Stop setting `MSBuildAllProjects`. Since these files are consumed from the NuGet package, it's not likely that they'll be changing once they are on disk.
- Use `$(MSBuildThisFileDirectory)` in the `buildMultiTargeting` folder to be more explicit in the path to the `build` file.
- Remove the `net46` buildMultiTargeting props file since that would never be used.
