### PR TITLE
Compatibility with MSBuild 14

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -91,7 +91,7 @@ Push-Location $libgit2Directory
     Set-Content -Encoding ASCII (Join-Path $projectDirectory "nuget.package\libgit2\libgit2_hash.txt") $sha
 
     $buildProperties = @"
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <libgit2_propsfile>`$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>$sha</libgit2_hash>
@@ -103,17 +103,29 @@ Push-Location $libgit2Directory
     Set-Content -Encoding UTF8 (Join-Path $projectDirectory "nuget.package\build\LibGit2Sharp.NativeBinaries.props") $buildProperties
 
     $net46BuildProperties = @"
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <libgit2_propsfile>`$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>$sha</libgit2_hash>
     <libgit2_filename>$binaryFilename</libgit2_filename>
   </PropertyGroup>
   <ItemGroup>
-    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*" TargetPath="lib\win32\x86\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*" TargetPath="lib\win32\x64\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\**\*`" Exclude="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*" TargetPath="lib\%(RecursiveDir)..\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config" TargetPath="LibGit2Sharp.dll.config" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*">
+      <TargetPath>lib\win32\x86\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*">
+      <TargetPath>lib\win32\x64\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\runtimes\**\*" Exclude="`$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*">
+      <TargetPath>lib\%(RecursiveDir)..\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="`$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
+      <TargetPath>LibGit2Sharp.dll.config</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
   </ItemGroup>
 </Project>
 "@

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>

--- a/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.props
@@ -1,13 +1,25 @@
-<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
     <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>
     <libgit2_filename>git2-572e4d8</libgit2_filename>
   </PropertyGroup>
   <ItemGroup>
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*" TargetPath="lib\win32\x86\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*" TargetPath="lib\win32\x64\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*" Exclude="$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*" TargetPath="lib\%(RecursiveDir)..\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config" TargetPath="LibGit2Sharp.dll.config" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*">
+      <TargetPath>lib\win32\x86\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*">
+      <TargetPath>lib\win32\x64\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*" Exclude="$(MSBuildThisFileDirectory)\..\..\runtimes\win-*\**\*">
+      <TargetPath>lib\%(RecursiveDir)..\%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
+      <TargetPath>LibGit2Sharp.dll.config</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ContentWithTargetPath>
   </ItemGroup>
 </Project>

--- a/nuget.package/buildMultiTargeting/LibGit2Sharp.NativeBinaries.props
+++ b/nuget.package/buildMultiTargeting/LibGit2Sharp.NativeBinaries.props
@@ -1,3 +1,3 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\..\build\LibGit2Sharp.NativeBinaries.props" />
 </Project>


### PR DESCRIPTION
Building a project which relies on LibGit2Sharp.0.26.0
(and therefore LibGit2Sharp.NativeBinaries.2.0.267) fails with this error
(output formatted):

    <project>\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props(1,1):
    error MSB4041: The default XML namespace of the project must be the MSBuild XML namespace.
    If the project is authored in the MSBuild 2003 format, please add xmlns="http://schemas.microsoft.com/developer/msbuild/2003" to the <Project> element.
    If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.

[Since MSBuild 15.0][1] the mentioned attribut is optional:

> Also the Xmlns attribute [of the Project element] is now optional.

Older versions of MSBuild (e.g. 14.0) do require this attribute.

This change adds this attribute to the Project element.

After this patch the build (with the recent version of LibGit2Sharp.NativeBinaries from GitHub) again fails:

    <project>\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props(9,98):
    error MSB4066: The attribute "TargetPath" in element <ContentWithTargetPath> is unrecognized.

Tweak the `ContentWithTargetPath` element: Change attributes `TargetPath` and `CopyToOutputDirectory` to inner elements.

This maybe also fixes [Can't parse project with reference to libgit2sharp](https://github.com/libgit2/libgit2sharp/issues/1613).

I propose this change because we build the project (which uses libgit2sharp) on a machine which has MSBuild 14.0 as the most recent version of MSBuild installed (and for various reasons the machine cannot be equipped with a more recent version of MSBuild).

[1]: https://docs.microsoft.com/en-us/visualstudio/msbuild/what-s-new-in-msbuild-15-0?view=vs-2017#updates "What's new in MSBuild 15"