### PR TITLE
Add linux-arm64 RID builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: RID=linux-arm64
+    - os: linux
+      dist: trusty
+      sudo: required
       env: RID=ubuntu.18.04-x64
     - os: linux
       dist: trusty

--- a/Dockerfile.linux-arm64
+++ b/Dockerfile.linux-arm64
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+WORKDIR /nativebinaries
+COPY . /nativebinaries/
+
+RUN dpkg --add-architecture arm64 \
+&& sed -i 's/deb/deb [arch=amd64]/g' /etc/apt/sources.list \
+&& echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports xenial main universe" > /etc/apt/sources.list.d/arm64.list \
+&& echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports xenial-updates main universe" > /etc/apt/sources.list.d/arm64-updates.list
+
+RUN apt update \
+&& apt -y install cmake pkg-config \
+   crossbuild-essential-arm64 \
+   pkg-config-aarch64-linux-gnu \
+   libssl-dev:arm64
+
+CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -123,6 +123,7 @@ Push-Location $libgit2Directory
     $dllConfig = @"
 <configuration>
     <dllmap os="linux" cpu="x86-64" wordsize="64" dll="$binaryFilename" target="lib/linux-x64/lib$binaryFilename.so" />
+    <dllmap os="linux" cpu="armv8" wordsize="64" dll="$binaryFilename" target="lib/linux-arm64/lib$binaryFilename.so" />
     <dllmap os="osx" cpu="x86,x86-64" dll="$binaryFilename" target="lib/osx/lib$binaryFilename.dylib" />
 </configuration>
 "@

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -34,6 +34,8 @@ PACKAGEPATH="nuget.package/runtimes"
 if [[ $RID == "" ]]; then
 	if [[ $ARCH == "x86_64" ]]; then
 		RID="unix-x64"
+	elif [[ $ARCH == "aarch64" ]]; then
+		RID="unix-arm64"
 	else
 		RID="unix-x86"
 	fi


### PR DESCRIPTION
The normal approach is to take the oldest OS supported and use that to make linux-$ARCH RID packages. Here, we use ubuntu 16.04.

This commit makes the following changes:

Add a new dockerfile for linux-arm64, which is actually just a copy of Dockerfile.ubuntu.16.04-arm64. This is so we can build linux-arm64 RID packages in CI.

Add a dllmap for mapping from armv8 (which is what mono calls arm64/aarch64 - see https://www.mono-project.com/docs/advanced/pinvoke/dllmap/) to the linux-arm64 RID.

Also fix build.libgit2.sh to handle building natively on arm64. I used this to build libgit2, using ./build.libgit2.sh, on RHEL 8 on arm64.