### PR TITLE
Update build scripts

### DIFF
--- a/Dockerfile.linux-x64
+++ b/Dockerfile.linux-x64
@@ -2,6 +2,8 @@ FROM ubuntu:14.04
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN apt update && apt -y install cmake libssl-dev pkg-config
+RUN apt update && apt -y install libssl-dev pkg-config curl make gcc build-essential
+
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.sh -o /tmp/cmake.sh && bash /tmp/cmake.sh --skip-license --prefix=/usr/local
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/Dockerfile.rhel-x64
+++ b/Dockerfile.rhel-x64
@@ -3,5 +3,6 @@ WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
 RUN yum -y install cmake gcc make openssl-devel
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.sh -o /tmp/cmake.sh && bash /tmp/cmake.sh --skip-license --prefix=/usr/local
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 LIBGIT2SHA=`cat ./nuget.package/libgit2/libgit2_hash.txt`
 SHORTSHA=${LIBGIT2SHA:0:7}
 
@@ -50,5 +52,3 @@ rm -rf $PACKAGEPATH/$RID
 mkdir -p $PACKAGEPATH/$RID/native
 
 cp libgit2/build/libgit2-$SHORTSHA.$LIBEXT $PACKAGEPATH/$RID/native
-
-exit $?

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 docker build -t $RID -f Dockerfile.$RID .
 
 docker run -it -e RID=$RID --name=$RID $RID


### PR DESCRIPTION
Update the build scripts to produce a `linux-x64` package.

The build scripts will now propagate failures, so CI runs will fail if artifacts were not produced (instead of giving the appearance of success, and ultimately producing nupkgs that lacked the artifacts).  The linux and rhel images now install a newer version of cmake, required for building libgit2.