### PR TITLE
RHEL: don't install cmake

### DIFF
--- a/Dockerfile.rhel-x64
+++ b/Dockerfile.rhel-x64
@@ -2,7 +2,7 @@ FROM centos:6
 WORKDIR /nativebinaries
 COPY . /nativebinaries/
 
-RUN yum -y install cmake gcc make openssl-devel
+RUN yum -y install gcc make openssl-devel
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.sh -o /tmp/cmake.sh && bash /tmp/cmake.sh --skip-license --prefix=/usr/local
 
 CMD ["/bin/bash", "-c", "./build.libgit2.sh"]


### PR DESCRIPTION
We update cmake ourselves, don't install the packaged version.