### PR TITLE
Build is compatible with CMake 3.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ do so easily with the scripts in this repository:
    installation, and will compile both x86 and amd64 variants.  (See
    "Notes on Visual Studio", below).  Run the build PowerShell script,
    specifying the version number of Visual Studio as the first argument.
-   For example, to build with Visual Studio 2013 (aka "Visual Studio 12.0"):
+   For example, to build with Visual Studio 2019:
 
-   `build.libgit2.ps1 12`
+   `build.libgit2.ps1 "16 2019"`
 
    For Linux, this will build only the architecture that you're running
    (x86 or amd64).  For Mac OS X, this will build a fat library that

--- a/build.libgit2.ps1
+++ b/build.libgit2.ps1
@@ -23,7 +23,7 @@ $libgit2Directory = Join-Path $projectDirectory "libgit2"
 $x86Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x86\native"
 $x64Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x64\native"
 $hashFile = Join-Path $projectDirectory "nuget.package\libgit2\libgit2_hash.txt"
-$sha = Get-Content $hashFile 
+$sha = Get-Content $hashFile
 
 if (![string]::IsNullOrEmpty($libgit2Name)) {
     $binaryFilename = $libgit2Name
@@ -124,7 +124,7 @@ try {
     cd ..
     Run-Command -Quiet { & mkdir build64 }
     cd build64
-    Run-Command -Quiet -Fatal { & $cmake -G "Visual Studio $vs Win64" -D THREADSAFE=ON -D ENABLE_TRACE=ON -D "BUILD_CLAR=$build_clar" -D "LIBGIT2_FILENAME=$binaryFilename" ../.. }
+    Run-Command -Quiet -Fatal { & $cmake -G "Visual Studio $vs" -A x64 -D THREADSAFE=ON -D ENABLE_TRACE=ON -D "BUILD_CLAR=$build_clar" -D "LIBGIT2_FILENAME=$binaryFilename" ../.. }
     Run-Command -Quiet -Fatal { & $cmake --build . --config $configuration }
     if ($test.IsPresent) { Run-Command -Quiet -Fatal { & $ctest -V . } }
     cd $configuration


### PR DESCRIPTION
Newer versions of CMake now take an `-A` option in addition to `-G` for
Visual Studio generators to allow the architecture to be specified. In
the 64-bit case, that's `-A x64`.