### PR TITLE
#111: Move libgit2 PDB files to legacy symbol package

### DIFF
--- a/Publish-Package.ps1
+++ b/Publish-Package.ps1
@@ -1,0 +1,49 @@
+<#
+  .SYNOPSIS
+  Publish the NativeBinaries package + symbols
+
+  .DESCRIPTION
+  Invokes the `nuget push` command using the specified symbol and package sources. The script
+  searches for `*.nupkg` files in the current working directory, but ignores files ending in
+  `*.symbols.nupkg` (since nuget handles those for us).
+
+  .PARAMETER PackagePushSource
+  Source to push the package (`*.nupkg`) to. Can be a local file path if testing locally.
+
+  .PARAMETER SymbolPushSource
+  Source to push the package (`*.symbols.nupkg`) to. Can be a local file path if testing locally.
+  Must be a path/URL different from the PackagePushSource.
+
+  .INPUTS
+  None. You cannot pipe objects into this script.
+
+  .OUTPUTS
+  None. This script does not generate any output.
+
+  .EXAMPLE
+  PS> Publish-Package.ps1
+
+  Publishes the package (and symbol package) to C:\packages and C:\symbols, respectively. Useful for
+  testing packages locally before publishing to nuget.org.
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $PackagePushSource,
+
+    [Parameter(Mandatory = $true)]
+    [string] $SymbolPushSource
+)
+
+# Push options for nuget. The presence of `-SymbolSource` makes nuget upload the .symbols.nupkg
+# files.
+$PushPackageOptions = (
+    "-Source", $PackagePushSource,
+    "-SymbolSource", $SymbolPushSource
+)
+
+# Push the packages + symbols.
+# Exclude symbol packages from the search because nuget handles those internally
+Get-ChildItem ".\LibGit2Sharp.NativeBinaries.*.nupkg" -Exclude "*.symbols.nupkg" |
+    ForEach-Object { .\nuget push $_.Name @PushPackageOptions }

--- a/buildpackage.ps1
+++ b/buildpackage.ps1
@@ -8,4 +8,9 @@ $buildDate = (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmmss")
 $versionSuffix = ""
 if ($pre.IsPresent) { $versionSuffix = "-pre$BuildDate" }
 
-.\nuget.exe Pack nuget.package\NativeBinaries.nuspec -Version $version$versionSuffix -NoPackageAnalysis
+# Create nuget package + legacy symbol pack
+# See: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages
+.\nuget.exe pack nuget.package\NativeBinaries.nuspec `
+    -Symbols `
+    -Version $version$versionSuffix `
+    -NoPackageAnalysis


### PR DESCRIPTION
* Upgrade nuget.exe to version 5.10.0.7240

  Newest version ensures best compatibility with nuget.org and support for
  symbol packages.

* Move libgit2 PDB files to legacy symbol package

  Nuget supports two types of symbol packages: [legacy][1] and
  [snuget][2]. The latter happens to be the newer implementation. Legacy
  symbol packages only exist for compatibility.
  
  It should be noted that, unfortunately, snuget symbol packages do not
  support Windows PDBs (the kind you get from C++ code). They only support
  portable PDBs (managed). As such, this patch provides support for legacy
  symbol package format. Note the following information from the symbol
  package MSDN documentation page:
  
  > Native projects, such as C++ projects, produce Windows PDBs instead of
  > Portable PDBs. These are not supported by NuGet.org's symbol server.
  > Please use Legacy Symbol Packages instead.
  
  Fixes #111
  
  [1]: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages
  [2]: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

* Add a script to publish the nuget package

  Is capable of publishing the nuget package *and* the symbol package.
  Supports local paths (for testing with a local nuget repository) and
  remote URLs.
  
  The command follows Microsoft conventions for Powershell scripts,
  including `Get-Help` support for command line documentation.
