### PR TITLE
Add MacOS Arm64 support (Take 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 5.0.x
       - name: Install MinVer
         run: dotnet tool install --global minver-cli
       - name: Run MinVer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
             name: linux-arm
           - os: macos-10.15
             name: osx-x64
+          - os: macos-11
+            name: osx-arm64
       fail-fast: false
     steps:
       - name: Checkout
@@ -69,7 +71,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install MinVer
         run: dotnet tool install --global minver-cli
       - name: Run MinVer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package contains the compiled versions of the libgit2 native library for
 the following platforms:
 
  - Windows (x86, x64, arm64)
- - macOS (x64)
+ - macOS (x64, arm64)
  - Linux (arm, arm64, x64)
 
  [lg2s-nb]: https://www.nuget.org/packages/LibGit2Sharp.NativeBinaries

--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -124,6 +124,7 @@ Push-Location $libgit2Directory
     <dllmap os="linux" cpu="arm" wordsize="32" dll="$binaryFilename" target="lib/linux-arm/lib$binaryFilename.so" />
     <dllmap os="linux" cpu="armv8" wordsize="64" dll="$binaryFilename" target="lib/linux-arm64/lib$binaryFilename.so" />
     <dllmap os="osx" cpu="x86-64" wordsize="64" dll="$binaryFilename" target="lib/osx-x64/lib$binaryFilename.dylib" />
+    <dllmap os="osx" cpu="arm64" wordsize="64" dll="$binaryFilename" target="lib/osx-arm64/lib$binaryFilename.dylib" />
 </configuration>
 "@
 

--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -124,7 +124,7 @@ Push-Location $libgit2Directory
     <dllmap os="linux" cpu="arm" wordsize="32" dll="$binaryFilename" target="lib/linux-arm/lib$binaryFilename.so" />
     <dllmap os="linux" cpu="armv8" wordsize="64" dll="$binaryFilename" target="lib/linux-arm64/lib$binaryFilename.so" />
     <dllmap os="osx" cpu="x86-64" wordsize="64" dll="$binaryFilename" target="lib/osx-x64/lib$binaryFilename.dylib" />
-    <dllmap os="osx" cpu="arm64" wordsize="64" dll="$binaryFilename" target="lib/osx-arm64/lib$binaryFilename.dylib" />
+    <dllmap os="osx" cpu="armv8" wordsize="64" dll="$binaryFilename" target="lib/osx-arm64/lib$binaryFilename.dylib" />
 </configuration>
 "@
 

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -28,8 +28,11 @@ if [[ $RID == *arm ]]; then
 	export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm.txt
 fi
 
-if [[ $RID == *arm64 ]] && [[ $OS != "Darwin" ]]; then
-	export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm64.txt
+if [[ $RID == *arm64 ]]; then
+    DCMAKEOSXARCHITECTURES="arm64"
+	if [[ $OS != "Darwin" ]]; then
+		export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm64.txt
+	fi
 fi
 
 cmake -DCMAKE_BUILD_TYPE:STRING=Release \

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -7,9 +7,13 @@ SHORTSHA=${LIBGIT2SHA:0:7}
 OS=`uname`
 ARCH=`uname -m`
 PACKAGEPATH="nuget.package/runtimes"
+DCMAKEOSXARCHITECTURES="x86_64"
 
 if [[ $OS == "Darwin" ]]; then
 	USEHTTPS="ON"
+	if [[ $ARCH == "arm64" ]]; then
+		DCMAKEOSXARCHITECTURES="arm64"
+	fi
 else
 	USEHTTPS="OpenSSL-Dynamic"
 fi
@@ -33,7 +37,7 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release \
       -DUSE_SSH=OFF \
       -DENABLE_TRACE=ON \
       -DLIBGIT2_FILENAME=git2-$SHORTSHA \
-      -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+      -DCMAKE_OSX_ARCHITECTURES=$DCMAKEOSXARCHITECTURES \
       -DUSE_HTTPS=$USEHTTPS \
       -DUSE_BUNDLED_ZLIB=ON \
       -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -7,12 +7,12 @@ SHORTSHA=${LIBGIT2SHA:0:7}
 OS=`uname`
 ARCH=`uname -m`
 PACKAGEPATH="nuget.package/runtimes"
-DCMAKEOSXARCHITECTURES="x86_64"
+OSXARCHITECTURE="x86_64"
 
 if [[ $OS == "Darwin" ]]; then
 	USEHTTPS="ON"
 	if [[ $ARCH == "arm64" ]]; then
-		DCMAKEOSXARCHITECTURES="arm64"
+		OSXARCHITECTURE="arm64"
 	fi
 else
 	USEHTTPS="OpenSSL-Dynamic"
@@ -29,7 +29,6 @@ if [[ $RID == *arm ]]; then
 fi
 
 if [[ $RID == *arm64 ]]; then
-    DCMAKEOSXARCHITECTURES="arm64"
 	if [[ $OS != "Darwin" ]]; then
 		export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm64.txt
 	fi
@@ -40,7 +39,7 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release \
       -DUSE_SSH=OFF \
       -DENABLE_TRACE=ON \
       -DLIBGIT2_FILENAME=git2-$SHORTSHA \
-      -DCMAKE_OSX_ARCHITECTURES=$DCMAKEOSXARCHITECTURES \
+      -DCMAKE_OSX_ARCHITECTURES=$OSXARCHITECTURE \
       -DUSE_HTTPS=$USEHTTPS \
       -DUSE_BUNDLED_ZLIB=ON \
       -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \

--- a/build.libgit2.sh
+++ b/build.libgit2.sh
@@ -28,7 +28,7 @@ if [[ $RID == *arm ]]; then
 	export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm.txt
 fi
 
-if [[ $RID == *arm64 ]]; then
+if [[ $RID == *arm64 ]] && [[ $OS != "Darwin" ]]; then
 	export TOOLCHAIN_FILE=/nativebinaries/CMakeLists.arm64.txt
 fi
 

--- a/nuget.package/libgit2/LibGit2Sharp.dll.config
+++ b/nuget.package/libgit2/LibGit2Sharp.dll.config
@@ -3,4 +3,5 @@
     <dllmap os="linux" cpu="arm" wordsize="32" dll="git2-b7bad55" target="lib/linux-arm/libgit2-b7bad55.so" />
     <dllmap os="linux" cpu="armv8" wordsize="64" dll="git2-b7bad55" target="lib/linux-arm64/libgit2-b7bad55.so" />
     <dllmap os="osx" cpu="x86-64" wordsize="64" dll="git2-b7bad55" target="lib/osx-x64/libgit2-b7bad55.dylib" />
+    <dllmap os="osx" cpu="arm64" wordsize="64" dll="git2-b7bad55" target="lib/osx-arm64/libgit2-b7bad55.dylib" />
 </configuration>

--- a/nuget.package/libgit2/LibGit2Sharp.dll.config
+++ b/nuget.package/libgit2/LibGit2Sharp.dll.config
@@ -3,5 +3,5 @@
     <dllmap os="linux" cpu="arm" wordsize="32" dll="git2-b7bad55" target="lib/linux-arm/libgit2-b7bad55.so" />
     <dllmap os="linux" cpu="armv8" wordsize="64" dll="git2-b7bad55" target="lib/linux-arm64/libgit2-b7bad55.so" />
     <dllmap os="osx" cpu="x86-64" wordsize="64" dll="git2-b7bad55" target="lib/osx-x64/libgit2-b7bad55.dylib" />
-    <dllmap os="osx" cpu="arm64" wordsize="64" dll="git2-b7bad55" target="lib/osx-arm64/libgit2-b7bad55.dylib" />
+    <dllmap os="osx" cpu="armv8" wordsize="64" dll="git2-b7bad55" target="lib/osx-arm64/libgit2-b7bad55.dylib" />
 </configuration>


### PR DESCRIPTION
This edits the scripts and yaml to include a `osx-arm64` target. This should add the correct dylib to the Nuget package to be consumed by the main libgit2 library.

<img width="843" alt="image" src="https://user-images.githubusercontent.com/898335/139518045-71e59661-f1db-4978-bba9-cbaf334d38ac.png">

Fixes https://github.com/libgit2/libgit2sharp.nativebinaries/issues/129

This also adds the review fixes from the previous PR. This does use Big Sur for compiling, since that's the only way to get the arm64 build.