### PR TITLE
Use expression instead of file for NuGet license

### DIFF
--- a/nuget.package/NativeBinaries.nuspec
+++ b/nuget.package/NativeBinaries.nuspec
@@ -4,7 +4,7 @@
     <id>LibGit2Sharp.NativeBinaries</id>
     <version>2.0.0</version>
     <authors>LibGit2Sharp contributors</authors>
-    <license type="file">libgit2\libgit2.license.txt</license>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/libgit2/libgit2sharp.nativebinaries</projectUrl>
     <icon>libgit2\libgit2.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
You can't set both and expressions are better because it allows tools to automatically determine the license.